### PR TITLE
Update rake version in template gemspec

### DIFF
--- a/airspace-jekyll.gemspec
+++ b/airspace-jekyll.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "jekyll", "~> 3.2"
   spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0.1"
 end


### PR DESCRIPTION
Update rake to version 13.0.1 to address https://github.com/advisories/GHSA-jppv-gw3r-w3q8